### PR TITLE
Fix issue with tap file format

### DIFF
--- a/Formula/python@2.rb
+++ b/Formula/python@2.rb
@@ -8,9 +8,9 @@ class PythonAT2 < Formula
 
   bottle do
     root_url "https://asana-oss-cache.s3.amazonaws.com/bottles"
-    sha256 "accfaa922708f00afb69ab230199f96e6ecdddd248a1eca586ce1e5e5cfd732b" => :catalina
-    sha256 "54d3351d6be8268b2f5017894dcc8e083811dfa3812bdb9f79f989873b9a4542" => :mojave
-    sha256 "cfd5c6eeac37065d19f527bb0798a9caf1928bab3340cd545224861a3c82f219" => :high_sierra
+    sha256 catalina:    "accfaa922708f00afb69ab230199f96e6ecdddd248a1eca586ce1e5e5cfd732b"
+    sha256 mojave:      "54d3351d6be8268b2f5017894dcc8e083811dfa3812bdb9f79f989873b9a4542"
+    sha256 high_sierra: "cfd5c6eeac37065d19f527bb0798a9caf1928bab3340cd545224861a3c82f219"
   end
 
   # setuptools remembers the build flags python is built with and uses them to


### PR DESCRIPTION
On Mac OS 11.3.1, running `mac_configure.sh` results in the following error:
```
Error: asana/pinned/python@2: Calling `sha256 "digest" => :tag` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the asana/pinned tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/asana/homebrew-pinned/Formula/python@2.rb:11
```
This commit updates the format so that it will run successfully.